### PR TITLE
Item list removal configuration feature unable to override elytra in disable_chestplate

### DIFF
--- a/common/src/main/java/com/beansgalaxy/backpacks/mixin/common/DataResourcesMixin.java
+++ b/common/src/main/java/com/beansgalaxy/backpacks/mixin/common/DataResourcesMixin.java
@@ -40,9 +40,7 @@ public class DataResourcesMixin {
 
             NonNullList<Item> items = NonNullList.create();
             items.add(Items.ELYTRA.asItem());
-            if (!Services.COMPAT.isModLoaded("elytraslot"))
-                  Constants.disableFromChestplate(items);
-            else
+            if (Services.COMPAT.isModLoaded("elytraslot"))
                   Constants.disablesBackSlot(items);
 
 

--- a/common/src/main/resources/data/beansbackpacks/modify/disable_chestplate
+++ b/common/src/main/resources/data/beansbackpacks/modify/disable_chestplate
@@ -1,0 +1,1 @@
+minecraft:elytra


### PR DESCRIPTION
This change should retain the exact same functionality, but allows for datapacks to override the elytra in the `disable_chestplate` item list.

This differs from adding the elytra to `disables_back_slot` since it allows for the elytra to not disable backpacks, while additionally ensuring that overrides supersede any other modification.